### PR TITLE
Add performance information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ node . update
 
 Validating a file against one of the provided schemas is the primary usage of this tool. Be sure that you have the latest schemas available by [running the update command](#update-available-schemas) first.
 
+The exact amount of time needed for the validator to run will vary based on input file size and the machine running the validator. On a sample system with a 2.60GHz CPU and 16GB of memory, a typical processing rate is approximately 25 megabytes of input per second.
+
 From the installed directory:
 
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.0",
-    "@types/nodegit": "^0.27.9",
     "@types/temp": "^0.9.1",
     "del-cli": "^4.0.1",
     "eslint": "^8.8.0",


### PR DESCRIPTION
Remove nodegit type information from dependencies, since nodegit
is not being used.