### PR TITLE
Validator exits on parse error

### DIFF
--- a/schemavalidator.cpp
+++ b/schemavalidator.cpp
@@ -230,6 +230,7 @@ int main(int argc, char *argv[]) {
         fprintf(errFile, "Error(offset %u): %s\n",
             static_cast<unsigned>(reader.GetErrorOffset()),
             GetParseError_En(reader.GetParseErrorCode()));
+        return EXIT_FAILURE;
     }
 
     // Check the validation result


### PR DESCRIPTION
Fixes #44 

If a parse error is encountered, the validator should exit immediately after logging the error. This avoids cases where there are parse errors, but no validation errors, which resulted in confusing output.