### PR TITLE
Exit with code 1 on error

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,6 +9,7 @@ export async function validate(dataFile: string, schemaVersion: string, options:
   // check to see if supplied json file exists
   if (!fs.existsSync(dataFile)) {
     console.log(`Could not find data file: ${dataFile}`);
+    process.exitCode = 1;
     return;
   }
   // get the schema that matches the chosen version and target name. then, use it to validate.
@@ -17,6 +18,7 @@ export async function validate(dataFile: string, schemaVersion: string, options:
       runContainer(schemaPath, dataFile, options.out);
     } else {
       console.log('No schema available - not validating.');
+      process.exitCode = 1;
     }
   });
 }
@@ -37,5 +39,6 @@ export async function update() {
     }
   } catch (error) {
     console.log(`Error when updating available schemas: ${error}`);
+    process.exitCode = 1;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,9 +52,11 @@ export async function useRepoVersion(schemaVersion: string, schemaName: string) 
           '\n'
         )}`
       );
+      process.exitCode = 1;
     }
   } catch (error) {
     console.log(`Error when accessing schema: ${error}`);
+    process.exitCode = 1;
   }
 }
 
@@ -105,11 +107,14 @@ export async function runContainer(schemaPath: string, dataPath: string, outputP
         .catch(reason => {
           console.log(reason.stdout);
           console.log(reason.stderr);
+          process.exitCode = 1;
         });
     } else {
       console.log('Could not find a validator docker container.');
+      process.exitCode = 1;
     }
   } catch (error) {
     console.log(`Error when running validator container: ${error}`);
+    process.exitCode = 1;
   }
 }


### PR DESCRIPTION
Addresses #55 

When a file successfully validates against the specified schema, exit with code 0. In all other cases, exit with code 1. This includes
validation failures, incorrect schema version tags, invalid paths to data files, and docker errors.