### PR TITLE
Add strict flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ git clone --recurse-submodules https://github.com/CMSgov/price-transparency-guid
 > **Hint**
 >
 > This repository references 3rd-party C++ libraries using Git submodules. If you clone without the `--recurse-submodules` flag, just run inside the repo:
+>
 > ```bash
 > git submodule update --init
 > ```
@@ -112,10 +113,13 @@ Arguments:
 
 Options:
   -o, --out <out>        output path
-  -t, --target <schema>  name of schema to use (choices: "allowed-amounts", "in-network-rates", "provider-reference",
-                         "table-of-contents", default: "in-network-rates")
+  -t, --target <schema>  name of schema to use (choices: "allowed-amounts", "in-network-rates", "provider-reference", "table-of-contents", default:
+                         "in-network-rates")
+  -s, --strict           enable strict checking, which prohibits additional properties in data file
   -h, --help             display help for command
 ```
+
+The purpose of the `strict` option is to help detect when an optional attribute has been spelled incorrectly. Because additional properties are allowed by the schema, a misspelled optional attribute does not normally cause a validation failure.
 
 ### Test file validation
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,7 +13,7 @@ export async function validate(dataFile: string, schemaVersion: string, options:
     return;
   }
   // get the schema that matches the chosen version and target name. then, use it to validate.
-  useRepoVersion(schemaVersion, options.target).then(schemaPath => {
+  useRepoVersion(schemaVersion, options.target, options.strict).then(schemaPath => {
     if (schemaPath != null) {
       runContainer(schemaPath, dataFile, options.out);
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ async function main() {
         .choices(config.AVAILABLE_SCHEMAS)
         .default('in-network-rates')
     )
+    .option(
+      '-s, --strict',
+      'enable strict checking, which prohibits additional properties in data file'
+    )
     .action(validate);
 
   program

--- a/test/fixtures/sampleSchema.json
+++ b/test/fixtures/sampleSchema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "food": {
+      "enum": [
+        "orange",
+        "apple",
+        "banana",
+        "pear"
+      ]
+    },
+    "garment": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "material": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "snacks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/food"
+      }
+    },
+    "clothes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/garment"
+      }
+    }
+  }
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -22,7 +22,7 @@ describe('utils', () => {
       );
       // since the container is running linux, it should always use / as its path separator.
       // but, the paths on the host system should be built by path
-      const expectedCommand = `docker run -v "${path.join(
+      const expectedCommand = `docker run --rm -v "${path.join(
         path.resolve(SEP),
         'some',
         'useful'
@@ -40,7 +40,7 @@ describe('utils', () => {
         path.join('results', 'output.txt'), // this is a relative path
         'dadb0d'
       );
-      const expectedCommand = `docker run -v "${path.join(
+      const expectedCommand = `docker run --rm -v "${path.join(
         PROJECT_DIR,
         'some',
         'useful'
@@ -55,8 +55,11 @@ describe('utils', () => {
   describe('#useRepoVersion', () => {
     let oldRepoFolder: string;
     beforeAll(async () => {
-      // set up our test repo
+      // set up our test repo with a sample schema
       const repoDirectory = temp.mkdirSync();
+      const sampleSchema = JSON.parse(
+        readFileSync(path.join(__dirname, 'fixtures', 'sampleSchema.json'), 'utf-8')
+      );
       ensureDirSync(path.join(repoDirectory, 'schemas', 'something-good'));
       oldRepoFolder = validatorUtils.config.SCHEMA_REPO_FOLDER;
       validatorUtils.config.SCHEMA_REPO_FOLDER = repoDirectory;
@@ -65,14 +68,17 @@ describe('utils', () => {
       await execP(`git -C "${repoDirectory}" config user.email "test-user@example.org"`);
       // create a few commits and tag them
       const schemaPath = path.join('schemas', 'something-good', 'something-good.json');
-      writeFileSync(path.join(repoDirectory, schemaPath), 'first schema info');
+      sampleSchema.version = '0.3';
+      writeFileSync(path.join(repoDirectory, schemaPath), JSON.stringify(sampleSchema));
       await execP(`git -C "${repoDirectory}" add -A`);
       await execP(`git -C "${repoDirectory}" commit -m "first commit"`);
       await execP(`git -C "${repoDirectory}" tag -a "v0.3" -m ""`);
-      writeFileSync(path.join(repoDirectory, schemaPath), 'schema for version 0.7');
+      sampleSchema.version = '0.7';
+      writeFileSync(path.join(repoDirectory, schemaPath), JSON.stringify(sampleSchema));
       await execP(`git -C "${repoDirectory}" commit -am "second commit"`);
       await execP(`git -C "${repoDirectory}" tag -a "v0.7" -m ""`);
-      writeFileSync(path.join(repoDirectory, schemaPath), 'this is the first published schema');
+      sampleSchema.version = '1.0';
+      writeFileSync(path.join(repoDirectory, schemaPath), JSON.stringify(sampleSchema));
       await execP(`git -C "${repoDirectory}" commit -am "third commit"`);
       await execP(`git -C "${repoDirectory}" tag -a "v1.0" -m ""`);
     });
@@ -85,8 +91,8 @@ describe('utils', () => {
     it('should return a file path to the schema contents at the specified version', async () => {
       const result = await validatorUtils.useRepoVersion('v0.7', 'something-good');
       expect(result).toBeDefined();
-      const contents = readFileSync(<string>result, { encoding: 'utf-8' });
-      expect(contents).toBe('schema for version 0.7');
+      const contents = JSON.parse(readFileSync(<string>result, { encoding: 'utf-8' }));
+      expect(contents.version).toBe('0.7');
     });
 
     it('should return undefined when the given tag is not available', async () => {
@@ -97,6 +103,16 @@ describe('utils', () => {
     it('should return undefined when the given schema is not available', async () => {
       const result = await validatorUtils.useRepoVersion('v0.3', 'something-bad');
       expect(result).toBeUndefined();
+    });
+
+    it('should set additionalProperties to false on all definitions when strict is true', async () => {
+      const result = await validatorUtils.useRepoVersion('v1.0', 'something-good', true);
+      expect(result).toBeDefined();
+      const contents = JSON.parse(readFileSync(<string>result, { encoding: 'utf-8' }));
+      expect(contents.version).toBe('1.0');
+      expect(contents.additionalProperties).toBeFalse();
+      expect(contents.definitions.food.additionalProperties).toBeFalse();
+      expect(contents.definitions.garment.additionalProperties).toBeFalse();
     });
   });
 });


### PR DESCRIPTION
Fixes #82 

Setting the strict flag causes the schema to be updated before being used. The updates made to the schema are:
- set additionalProperties to false at the top level of the schema
- set additionalProperties to false for each definition

This is helpful for detecting spelling errors in optional attribute names.