### PR TITLE
Continue with zip contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "del-cli out && tsc",
     "prettier": "prettier --check \"src/*.ts\"",
+    "prepare": "npm run build",
     "test": "jest --maxWorkers=4 --coverage"
   },
   "repository": {


### PR DESCRIPTION
After validating a file within a ZIP archive, ask the user if they want to validate another file in the ZIP. If they say yes, show the file selection menu again. If they say no, exit. The user is allowed to validate another file regardless of the validation result, as long as the validator container executes successfully.