### PR TITLE
Add -O3 compiler flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install -y g++ cmake doxygen valgrind wget
 COPY ./schemavalidator.cpp /
 COPY ./rapidjson /rapidjson
 COPY ./tclap /tclap
-RUN g++ -I /rapidjson/include -I /tclap/include/ schemavalidator.cpp -o validator
+RUN g++ -O3 -I /rapidjson/include -I /tclap/include/ schemavalidator.cpp -o validator
 
 FROM ubuntu
 COPY --from=build /validator /validator


### PR DESCRIPTION
Here is some background on the `-On` flags in g++: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html. `-O3` means optimize for speed over compilation time or binary size.

## Test results

I grabbed [this medium sized MRF](https://uhc-tic-mrf.azureedge.net/public-mrf/2023-05-01/2023-05-01_United-HealthCare-Services--Inc-_Third-Party-Administrator_PPO---NDC_PPO-NDC_in-network-rates.json.gz) from UnitedHealthcare to test with, and ran `gunzip` on the file before running this test. The file is approximately 875MB uncompressed.

```
karthik@karthik ~/price-transparency-guide-validator (main)> ls -alh ~/2023-05-01_United-HealthCare-Services--Inc-_Third-Party-Administrator_PPO---NDC_PPO-NDC_in-network-rates.json
-rw-r--r--. 1 karthik karthik 875M Apr 17 14:23 /home/karthik/2023-05-01_United-HealthCare-Services--Inc-_Third-Party-Administrator_PPO---NDC_PPO-NDC_in-network-rates.json
```

Before (~133 seconds which is ~6.5MBps)

```
karthik@karthik ~/price-transparency-guide-validator (main)> time cms-mrf-validator validate ~/2023-05-01_United-HealthCare-Services--Inc-_Third-Party-Administrator_PPO---NDC_PPO-NDC_in-network-rates.json v1.3.3
Running validator container...
Input JSON is valid.


________________________________________________________
Executed in  133.74 secs      fish           external
   usr time  245.76 millis    0.08 millis  245.68 millis
   sys time   86.31 millis    1.04 millis   85.27 millis
```

After (~26 seconds which is ~33MBps)

```
karthik@karthik ~/price-transparency-guide-validator (main)> time cms-mrf-validator validate ~/2023-05-01_United-HealthCare-Services--Inc-_Third-Party-Administrator_PPO---NDC_PPO-NDC_in-network-rates.json v1.3.3
Running validator container...
Input JSON is valid.


________________________________________________________
Executed in   26.52 secs      fish           external
   usr time  249.42 millis    0.11 millis  249.31 millis
   sys time  107.07 millis    1.05 millis  106.02 millis
```

My system is pretty similar to the example in the README (16GB of memory, normal clockspeed, etc). Given that the README says to expect 25MBps, I suspect that whoever ran that benchmark was using `-O3` or other optimization flags in the compiler anyway.