### PR TITLE
Better file type detection when URL has query string

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -313,14 +313,14 @@ function isGzip(contentType: string, url: string): boolean {
   return (
     contentType === 'application/gzip' ||
     contentType === 'application/x-gzip' ||
-    (contentType === 'application/octet-stream' && url.endsWith('.gz'))
+    (contentType === 'application/octet-stream' && /\.gz(\?|$)/.test(url))
   );
 }
 
 function isZip(contentType: string, url: string): boolean {
   return (
     contentType === 'application/zip' ||
-    (contentType === 'application/octet-stream' && url.endsWith('.zip'))
+    (contentType === 'application/octet-stream' && /\.zip(\?|$)/.test(url))
   );
 }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -232,6 +232,26 @@ describe('utils', () => {
       expect(downloadedData).toEqual(simpleData);
     });
 
+    it('should write a decompressed gz file when the response has content type application/octet-stream and the url ends with .gz followed by a query string', async () => {
+      const simpleData = fs.readJsonSync(
+        path.join(__dirname, 'fixtures', 'simpleData.json'),
+        'utf-8'
+      );
+      const simpleGz = fs.readFileSync(path.join(__dirname, 'fixtures', 'simpleData.gz'));
+      nock('http://example.org')
+        .get('/data.gz')
+        .query(true)
+        .reply(200, simpleGz, { 'content-type': 'application/octet-stream' });
+      const outputDir = temp.mkdirSync();
+      await validatorUtils.downloadDataFile(
+        'http://example.org/data.gz?Expires=123456&mode=true',
+        outputDir
+      );
+      expect(fs.existsSync(path.join(outputDir, 'data.json')));
+      const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
+      expect(downloadedData).toEqual(simpleData);
+    });
+
     it('should write a json file within a zip to the specified folder', async () => {
       const simpleData = fs.readJsonSync(
         path.join(__dirname, 'fixtures', 'simpleData.json'),
@@ -259,6 +279,26 @@ describe('utils', () => {
         .reply(200, simpleZip, { 'content-type': 'application/octet-stream' });
       const outputDir = temp.mkdirSync();
       await validatorUtils.downloadDataFile('http://example.org/data.zip', outputDir);
+      expect(fs.existsSync(path.join(outputDir, 'data.json')));
+      const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
+      expect(downloadedData).toEqual(simpleData);
+    });
+
+    it('should write a json file within a zip when the response has content type application/octet-stream and the url ends with .zip followed by a query string', async () => {
+      const simpleData = fs.readJsonSync(
+        path.join(__dirname, 'fixtures', 'simpleData.json'),
+        'utf-8'
+      );
+      const simpleZip = fs.readFileSync(path.join(__dirname, 'fixtures', 'simpleZip.zip'));
+      nock('http://example.org')
+        .get('/data.zip')
+        .query(true)
+        .reply(200, simpleZip, { 'content-type': 'application/octet-stream' });
+      const outputDir = temp.mkdirSync();
+      await validatorUtils.downloadDataFile(
+        'http://example.org/data.zip?mode=on&rate=7',
+        outputDir
+      );
       expect(fs.existsSync(path.join(outputDir, 'data.json')));
       const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
       expect(downloadedData).toEqual(simpleData);


### PR DESCRIPTION
Fixes #93.

When a downloaded file's content-type is "application/octet-stream", check the URL to try to determine file type. If the URL includes a query string, it should appear immediately after the part of the URL that has the file extension. If there is no query string, the file extension will be the last part of the URL.