### PR TITLE
Detect zip/gzip when a download request is redirected

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,7 +113,8 @@ export async function downloadDataFile(url: string, folder: string): Promise<str
     })
       .then(response => {
         const contentType = response.headers['content-type'] ?? 'application/octet-stream';
-        if (isZip(contentType, url)) {
+        const finalUrl = response.request.path;
+        if (isZip(contentType, finalUrl)) {
           // zips require additional work to find a JSON file inside
           const zipPath = path.join(folder, 'data.zip');
           const zipOutputStream = fs.createWriteStream(zipPath);
@@ -172,7 +173,7 @@ export async function downloadDataFile(url: string, folder: string): Promise<str
             reject('Error writing downloaded file.');
           });
 
-          if (isGzip(contentType, url)) {
+          if (isGzip(contentType, finalUrl)) {
             pipeline(response.data, createGunzip(), outputStream);
           } else {
             response.data.pipe(outputStream);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -142,6 +142,45 @@ describe('utils', () => {
       expect(downloadedData).toEqual(simpleData);
     });
 
+    it('should write a decompressed gz file when the response has content type application/octet-stream and the url after redirection ends with .gz', async () => {
+      const simpleData = fs.readJsonSync(
+        path.join(__dirname, 'fixtures', 'simpleData.json'),
+        'utf-8'
+      );
+      const simpleGz = fs.readFileSync(path.join(__dirname, 'fixtures', 'simpleData.gz'));
+      nock('http://example.org')
+        .get('/some-data')
+        .reply(302, '', { Location: 'http://example.org/data.gz' });
+      nock('http://example.org')
+        .get('/data.gz')
+        .reply(200, simpleGz, { 'content-type': 'application/octet-stream' });
+      const outputDir = temp.mkdirSync();
+      await validatorUtils.downloadDataFile('http://example.org/some-data', outputDir);
+      expect(fs.existsSync(path.join(outputDir, 'data.json')));
+      const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
+      expect(downloadedData).toEqual(simpleData);
+    });
+
+    it('should write a decompressed gz file when the response has content type application/octet-stream and the url after redirection ends with .gz followed by a query string', async () => {
+      const simpleData = fs.readJsonSync(
+        path.join(__dirname, 'fixtures', 'simpleData.json'),
+        'utf-8'
+      );
+      const simpleGz = fs.readFileSync(path.join(__dirname, 'fixtures', 'simpleData.gz'));
+      nock('http://example.org')
+        .get('/some-data')
+        .reply(302, '', { Location: 'http://example.org/data.gz?Expires=123456&mode=true' });
+      nock('http://example.org')
+        .get('/data.gz')
+        .query(true)
+        .reply(200, simpleGz, { 'content-type': 'application/octet-stream' });
+      const outputDir = temp.mkdirSync();
+      await validatorUtils.downloadDataFile('http://example.org/some-data', outputDir);
+      expect(fs.existsSync(path.join(outputDir, 'data.json')));
+      const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
+      expect(downloadedData).toEqual(simpleData);
+    });
+
     it('should write a json file within a zip to the specified folder', async () => {
       const simpleData = fs.readJsonSync(
         path.join(__dirname, 'fixtures', 'simpleData.json'),
@@ -189,6 +228,45 @@ describe('utils', () => {
         'http://example.org/data.zip?mode=on&rate=7',
         outputDir
       );
+      expect(fs.existsSync(path.join(outputDir, 'data.json')));
+      const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
+      expect(downloadedData).toEqual(simpleData);
+    });
+
+    it('should write a json file within a zip when the response has content type application/octet-stream and the url after redirection ends with .zip', async () => {
+      const simpleData = fs.readJsonSync(
+        path.join(__dirname, 'fixtures', 'simpleData.json'),
+        'utf-8'
+      );
+      const simpleZip = fs.readFileSync(path.join(__dirname, 'fixtures', 'simpleZip.zip'));
+      nock('http://example.org')
+        .get('/data-please')
+        .reply(302, '', { Location: 'http://example.org/data.zip' });
+      nock('http://example.org')
+        .get('/data.zip')
+        .reply(200, simpleZip, { 'content-type': 'application/octet-stream' });
+      const outputDir = temp.mkdirSync();
+      await validatorUtils.downloadDataFile('http://example.org/data-please', outputDir);
+      expect(fs.existsSync(path.join(outputDir, 'data.json')));
+      const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
+      expect(downloadedData).toEqual(simpleData);
+    });
+
+    it('should write a json file within a zip when the response has content type application/octet-stream and the url after redirection ends with .zip followed by a query string', async () => {
+      const simpleData = fs.readJsonSync(
+        path.join(__dirname, 'fixtures', 'simpleData.json'),
+        'utf-8'
+      );
+      const simpleZip = fs.readFileSync(path.join(__dirname, 'fixtures', 'simpleZip.zip'));
+      nock('http://example.org')
+        .get('/data-please')
+        .reply(302, '', { Location: 'http://example.org/data.zip?mode=on&rate=7' });
+      nock('http://example.org')
+        .get('/data.zip')
+        .query(true)
+        .reply(200, simpleZip, { 'content-type': 'application/octet-stream' });
+      const outputDir = temp.mkdirSync();
+      await validatorUtils.downloadDataFile('http://example.org/data-please', outputDir);
       expect(fs.existsSync(path.join(outputDir, 'data.json')));
       const downloadedData = fs.readJsonSync(path.join(outputDir, 'data.json'), 'utf-8');
       expect(downloadedData).toEqual(simpleData);


### PR DESCRIPTION
Fixes #101 

If a download request is redirected, the final request URL will be different from the original request URL. Use the final request URL when assessing an application/octet-stream response.