### PR TITLE
Detect schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Options:
   -h, --help                                       display help for command
 
 Commands:
-  validate [options] <data-file> <schema-version>  Validate a file against a specific published version of a CMS schema.
-  from-url [options] <data-url> <schema-version>   Validate the file retrieved from a URL against a specific published version of a CMS schema.
-  update                                           Update the available schemas from the CMS repository.
-  help [command]                                   display help for command
+  validate [options] <data-file>  Validate a file against a specific published version of a CMS schema.
+  from-url [options] <data-url>   Validate the file retrieved from a URL against a specific published version of a CMS schema.
+  update                          Update the available schemas from the CMS repository.
+  help [command]                  display help for command
 ```
 
 ### Update available schemas
@@ -92,16 +92,16 @@ Validating a file against one of the provided schemas is the primary usage of th
 From the installed directory:
 
 ```
-cms-mrf-validator validate <data-file> <schema-version> [-o out] [-t target]
+cms-mrf-validator validate <data-file> [options]
 ```
 
 Example usages:
 
 ```bash
-# basic usage, printing output directly and using the default in-network-rates schema
-cms-mrf-validator validate my-data.json v1.0.0
-# output will be written to a file. validate using allowed-amounts schema
-cms-mrf-validator validate my-data.json v1.0.0 -o results.txt -t allowed-amounts
+# basic usage, printing output directly and using the default in-network-rates schema with the version specified in the file
+cms-mrf-validator validate my-data.json
+# output will be written to a file. validate using specific version of allowed-amounts schema
+cms-mrf-validator validate my-data.json --schema-version v1.0.0 -o results.txt -t allowed-amounts
 ```
 
 Further details:
@@ -110,14 +110,15 @@ Further details:
 Validate a file against a specific published version of a CMS schema.
 
 Arguments:
-  data-file              path to data file to validate
-  schema-version         version of schema to use for validation
+  data-file                   path to data file to validate
 
 Options:
-  -o, --out <out>        output path
-  -t, --target <schema>  name of schema to use (choices: "allowed-amounts", "in-network-rates", "provider-reference", "table-of-contents", default: "in-network-rates")
-  -s, --strict           enable strict checking, which prohibits additional properties in data file
-  -h, --help             display help for command
+  --schema-version <version>  version of schema to use for validation
+  -o, --out <out>             output path
+  -t, --target <schema>       name of schema to use (choices: "allowed-amounts", "in-network-rates", "provider-reference", "table-of-contents",
+                              default: "in-network-rates")
+  -s, --strict                enable strict checking, which prohibits additional properties in data file
+  -h, --help                  display help for command
 ```
 
 The purpose of the `strict` option is to help detect when an optional attribute has been spelled incorrectly. Because additional properties are allowed by the schema, a misspelled optional attribute does not normally cause a validation failure.
@@ -127,7 +128,7 @@ The purpose of the `strict` option is to help detect when an optional attribute 
 It is also possible to specify a URL to the file to validate. From the installed directory:
 
 ```
-cms-mrf-validator from-url <data-url> <schema-version> [-o out] [-t target]
+cms-mrf-validator from-url <data-url> [options]
 ```
 
 The only difference in arguments is that a URL should be provided instead of a path to a file. All options from the `validate` command still apply. The URL must return a file that is one of the following:
@@ -142,14 +143,15 @@ Further details:
 Validate the file retrieved from a URL against a specific published version of a CMS schema.
 
 Arguments:
-  data-url               URL to data file to validate
-  schema-version         version of schema to use for validation
+  data-url                    URL to data file to validate
 
 Options:
-  -o, --out <out>        output path
-  -t, --target <schema>  name of schema to use (choices: "allowed-amounts", "in-network-rates", "provider-reference", "table-of-contents", default: "in-network-rates")
-  -s, --strict           enable strict checking, which prohibits additional properties in data file
-  -h, --help             display help for command
+  --schema-version <version>  version of schema to use for validation
+  -o, --out <out>             output path
+  -t, --target <schema>       name of schema to use (choices: "allowed-amounts", "in-network-rates", "provider-reference", "table-of-contents",
+                              default: "in-network-rates")
+  -s, --strict                enable strict checking, which prohibits additional properties in data file
+  -h, --help                  display help for command
 ```
 
 ### Test file validation
@@ -161,7 +163,7 @@ Running the command from the root of the project:
 #### Running a valid file:
 
 ```bash
-cms-mrf-validator validate test-files/in-network-rates-fee-for-service-sample.json v1.0.0
+cms-mrf-validator validate test-files/in-network-rates-fee-for-service-sample.json --schema-version v1.0.0
 ```
 
 Output:
@@ -173,7 +175,7 @@ Input JSON is valid.
 #### Running an invalid file:
 
 ```bash
-cms-mrf-validator validate test-files/allowed-amounts-error.json v1.0.0 -t allowed-amounts
+cms-mrf-validator validate test-files/allowed-amounts-error.json --schema-version v1.0.0 -t allowed-amounts
 ```
 
 Output:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "chalk": "^3.0.0",
         "commander": "^8.3.0",
         "fs-extra": "^10.0.0",
+        "JSONStream": "^1.3.5",
         "readline-sync": "^1.4.10",
         "temp": "^0.9.4",
         "winston": "^3.10.0",
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.2.5",
+        "@types/JSONStream": "npm:@types/jsonstream@^0.8.31",
         "@types/node": "^20.4.8",
         "@types/readline-sync": "^1.4.4",
         "@types/temp": "^0.9.1",
@@ -1646,6 +1648,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/@types/JSONStream": {
+      "name": "@types/jsonstream",
+      "version": "0.8.31",
+      "resolved": "https://registry.npmjs.org/@types/jsonstream/-/jsonstream-0.8.31.tgz",
+      "integrity": "sha512-32nJ7wl+q0lebxHo8iXqpmgLmkj6lYNHKp97+h8qteQ6O6IKnY+GyD/Eitqi4ul2Bbw3MScfRKtaHxt8gpC98w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -5619,6 +5631,29 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "engines": [
+        "node >= 0.2.0"
+      ]
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6956,6 +6991,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -8576,6 +8616,15 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
+      }
+    },
+    "@types/JSONStream": {
+      "version": "npm:@types/jsonstream@0.8.31",
+      "resolved": "https://registry.npmjs.org/@types/jsonstream/-/jsonstream-0.8.31.tgz",
+      "integrity": "sha512-32nJ7wl+q0lebxHo8iXqpmgLmkj6lYNHKp97+h8qteQ6O6IKnY+GyD/Eitqi4ul2Bbw3MScfRKtaHxt8gpC98w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/minimist": {
@@ -11585,6 +11634,20 @@
         }
       }
     },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -12549,6 +12612,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@streamparser/json": "^0.0.17",
+        "@streamparser/json-node": "^0.0.17",
         "axios": "^1.2.1",
         "chalk": "^3.0.0",
         "commander": "^8.3.0",
         "fs-extra": "^10.0.0",
-        "JSONStream": "^1.3.5",
         "readline-sync": "^1.4.10",
         "temp": "^0.9.4",
         "winston": "^3.10.0",
@@ -25,7 +26,6 @@
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.2.5",
-        "@types/JSONStream": "npm:@types/jsonstream@^0.8.31",
         "@types/node": "^20.4.8",
         "@types/readline-sync": "^1.4.4",
         "@types/temp": "^0.9.1",
@@ -1524,6 +1524,19 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.17.tgz",
+      "integrity": "sha512-mW54K6CTVJVLwXRB6kSS1xGWPmtTuXAStWnlvtesmcySgtop+eFPWOywBFPpJO4UD173epYsPSP6HSW8kuqN8w=="
+    },
+    "node_modules/@streamparser/json-node": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@streamparser/json-node/-/json-node-0.0.17.tgz",
+      "integrity": "sha512-5y9ZFTp/LHljq7wpcliuNK+80qWxmtfeK7AEojy3snN8TMkChDz0a11NU+118ehY3Q9Is0eUxnQSAAaBQB6zWg==",
+      "dependencies": {
+        "@streamparser/json": "^0.0.17"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -1648,16 +1661,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
-    },
-    "node_modules/@types/JSONStream": {
-      "name": "@types/jsonstream",
-      "version": "0.8.31",
-      "resolved": "https://registry.npmjs.org/@types/jsonstream/-/jsonstream-0.8.31.tgz",
-      "integrity": "sha512-32nJ7wl+q0lebxHo8iXqpmgLmkj6lYNHKp97+h8qteQ6O6IKnY+GyD/Eitqi4ul2Bbw3MScfRKtaHxt8gpC98w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -5631,29 +5634,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "engines": [
-        "node >= 0.2.0"
-      ]
-    },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6991,11 +6971,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -8500,6 +8475,19 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@streamparser/json": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.17.tgz",
+      "integrity": "sha512-mW54K6CTVJVLwXRB6kSS1xGWPmtTuXAStWnlvtesmcySgtop+eFPWOywBFPpJO4UD173epYsPSP6HSW8kuqN8w=="
+    },
+    "@streamparser/json-node": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@streamparser/json-node/-/json-node-0.0.17.tgz",
+      "integrity": "sha512-5y9ZFTp/LHljq7wpcliuNK+80qWxmtfeK7AEojy3snN8TMkChDz0a11NU+118ehY3Q9Is0eUxnQSAAaBQB6zWg==",
+      "requires": {
+        "@streamparser/json": "^0.0.17"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
@@ -8616,15 +8604,6 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
-      }
-    },
-    "@types/JSONStream": {
-      "version": "npm:@types/jsonstream@0.8.31",
-      "resolved": "https://registry.npmjs.org/@types/jsonstream/-/jsonstream-0.8.31.tgz",
-      "integrity": "sha512-32nJ7wl+q0lebxHo8iXqpmgLmkj6lYNHKp97+h8qteQ6O6IKnY+GyD/Eitqi4ul2Bbw3MScfRKtaHxt8gpC98w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/minimist": {
@@ -11634,20 +11613,6 @@
         }
       }
     },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
-    },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -12612,11 +12577,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.2.5",
-    "@types/JSONStream": "npm:@types/jsonstream@^0.8.31",
     "@types/node": "^20.4.8",
     "@types/readline-sync": "^1.4.4",
     "@types/temp": "^0.9.1",
@@ -44,11 +43,12 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
+    "@streamparser/json": "^0.0.17",
+    "@streamparser/json-node": "^0.0.17",
     "axios": "^1.2.1",
     "chalk": "^3.0.0",
     "commander": "^8.3.0",
     "fs-extra": "^10.0.0",
-    "JSONStream": "^1.3.5",
     "readline-sync": "^1.4.10",
     "temp": "^0.9.4",
     "winston": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.2.5",
+    "@types/JSONStream": "npm:@types/jsonstream@^0.8.31",
     "@types/node": "^20.4.8",
     "@types/readline-sync": "^1.4.4",
     "@types/temp": "^0.9.1",
@@ -47,6 +48,7 @@
     "chalk": "^3.0.0",
     "commander": "^8.3.0",
     "fs-extra": "^10.0.0",
+    "JSONStream": "^1.3.5",
     "readline-sync": "^1.4.10",
     "temp": "^0.9.4",
     "winston": "^3.10.0",

--- a/src/SchemaManager.ts
+++ b/src/SchemaManager.ts
@@ -8,6 +8,7 @@ import { logger } from './logger';
 import { JSONParser } from '@streamparser/json-node';
 
 const VERSION_TIME_LIMIT = 3000; // three seconds
+const BACKWARDS_BYTES = 1000; // read the last 1000 bytes during backwards search
 
 export class SchemaManager {
   private _version: string;
@@ -127,8 +128,8 @@ export class SchemaManager {
             try {
               const stats = await fileHandle.stat();
               const lastStuff = await fileHandle.read({
-                position: Math.max(0, stats.size - 100),
-                length: 100
+                position: Math.max(0, stats.size - BACKWARDS_BYTES),
+                length: BACKWARDS_BYTES
               });
               if (lastStuff.bytesRead > 0) {
                 const lastText = lastStuff.buffer.toString('utf-8');

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -99,6 +99,10 @@ export async function validate(dataFile: string, options: OptionValues) {
         process.exitCode = 1;
       }
       temp.cleanupSync();
+    })
+    .catch(err => {
+      logger.error(err.message);
+      process.exitCode = 1;
     });
 }
 
@@ -175,6 +179,10 @@ export async function validateFromUrl(dataUrl: string, options: OptionValues) {
           logger.error('No schema available - not validating.');
           process.exitCode = 1;
         }
+      })
+      .catch(err => {
+        logger.error(err.message);
+        process.exitCode = 1;
       });
   } else {
     logger.info('Exiting.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,9 @@ async function main() {
     })
     .command('validate')
     .description('Validate a file against a specific published version of a CMS schema.')
-    .usage('<data-file> <schema-version> [options]')
+    .usage('<data-file> [options]')
     .argument('<data-file>', 'path to data file to validate')
-    .argument('<schema-version>', 'version of schema to use for validation')
+    .option('--schema-version <version>', 'version of schema to use for validation')
     .option('-o, --out <out>', 'output path')
     .addOption(
       new Option('-t, --target <schema>', 'name of schema to use')
@@ -42,9 +42,9 @@ async function main() {
     .description(
       'Validate the file retrieved from a URL against a specific published version of a CMS schema.'
     )
-    .usage('<data-url> <schema-version> [options]')
+    .usage('<data-url> [options]')
     .argument('<data-url>', 'URL to data file to validate')
-    .argument('<schema-version>', 'version of schema to use for validation')
+    .option('--schema-version <version>', 'version of schema to use for validation')
     .option('-o, --out <out>', 'output path')
     .addOption(
       new Option('-t, --target <schema>', 'name of schema to use')
@@ -55,8 +55,8 @@ async function main() {
       '-s, --strict',
       'enable strict checking, which prohibits additional properties in data file'
     )
-    .action((dataUrl, schemaVersion, options) => {
-      validateFromUrl(dataUrl, schemaVersion, options).then(result => {
+    .action((dataUrl, options) => {
+      validateFromUrl(dataUrl, options).then(result => {
         if (result) {
           process.exitCode = 0;
         } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -348,78 +348,253 @@ export async function validateTocContents(
   if (outputPath?.length > 0) {
     tempOutput = path.join(temp.mkdirSync('contents'), 'contained-result');
   }
-  const providerReferences: Set<string> = new Set<string>();
+  let providerReferences: Set<string>;
   if (inNetwork.length > 0) {
-    await schemaManager.useSchema('in-network-rates').then(async schemaPath => {
-      if (schemaPath != null) {
-        for (const dataUrl of inNetwork) {
-          try {
-            if (await checkDataUrl(dataUrl)) {
-              logger.info(`File: ${dataUrl}`);
-              const dataPath = await downloadDataFile(dataUrl, temp.mkdirSync());
-              if (typeof dataPath === 'string') {
-                const containedResult = await dockerManager.runContainer(
+    if (schemaManager.shouldDetectVersion) {
+      providerReferences = await validateInNetworkDetectedVersion(
+        inNetwork,
+        schemaManager,
+        dockerManager,
+        outputPath,
+        tempOutput
+      );
+    } else {
+      providerReferences = await validateInNetworkFixedVersion(
+        inNetwork,
+        schemaManager,
+        dockerManager,
+        outputPath,
+        tempOutput
+      );
+    }
+  }
+  if (allowedAmount.length > 0) {
+    if (schemaManager.shouldDetectVersion) {
+      await validateAllowedAmountsDetectedVersion(
+        allowedAmount,
+        schemaManager,
+        dockerManager,
+        outputPath,
+        tempOutput
+      );
+    } else {
+      await validateAllowedAmountsFixedVersion(
+        allowedAmount,
+        schemaManager,
+        dockerManager,
+        outputPath,
+        tempOutput
+      );
+    }
+  }
+  return [...providerReferences.values()];
+}
+
+async function validateInNetworkFixedVersion(
+  inNetwork: string[],
+  schemaManager: SchemaManager,
+  dockerManager: DockerManager,
+  outputPath: string,
+  tempOutput: string
+) {
+  const providerReferences: Set<string> = new Set<string>();
+  await schemaManager.useSchema('in-network-rates').then(async schemaPath => {
+    if (schemaPath != null) {
+      for (const dataUrl of inNetwork) {
+        try {
+          if (await checkDataUrl(dataUrl)) {
+            logger.info(`File: ${dataUrl}`);
+            const dataPath = await downloadDataFile(dataUrl, temp.mkdirSync());
+            if (typeof dataPath === 'string') {
+              // check if detected version matches the provided version
+              // if there's no version property, that's ok
+              await schemaManager
+                .determineVersion(dataPath)
+                .then(detectedVersion => {
+                  if (detectedVersion != schemaManager.version) {
+                    logger.warn(
+                      `Schema version ${schemaManager.version} was provided, but file indicates it conforms to schema version ${detectedVersion}. ${schemaManager.version} will be used.`
+                    );
+                  }
+                })
+                .catch(() => {});
+              const containedResult = await dockerManager.runContainer(
+                schemaPath,
+                'in-network-rates',
+                dataPath,
+                tempOutput
+              );
+              if (
+                containedResult.pass &&
+                containedResult.locations?.providerReference?.length > 0
+              ) {
+                containedResult.locations.providerReference.forEach(prf =>
+                  providerReferences.add(prf)
+                );
+              }
+              if (tempOutput.length > 0) {
+                appendResults(tempOutput, outputPath, `${dataUrl} - in-network${EOL}`);
+              }
+            }
+          } else {
+            logger.error(`Could not download file: ${dataUrl}`);
+          }
+        } catch (err) {
+          logger.error('Problem validating referenced in-network file', err);
+        }
+      }
+    } else {
+      logger.error('No schema available - not validating.');
+    }
+  });
+  return providerReferences;
+}
+
+async function validateInNetworkDetectedVersion(
+  inNetwork: string[],
+  schemaManager: SchemaManager,
+  dockerManager: DockerManager,
+  outputPath: string,
+  tempOutput: string
+) {
+  const providerReferences: Set<string> = new Set<string>();
+  for (const dataUrl of inNetwork) {
+    try {
+      if (await checkDataUrl(dataUrl)) {
+        logger.info(`File: ${dataUrl}`);
+        const dataPath = await downloadDataFile(dataUrl, temp.mkdirSync());
+        if (typeof dataPath === 'string') {
+          const versionToUse = await schemaManager.determineVersion(dataPath);
+          await schemaManager
+            .useVersion(versionToUse)
+            .then(versionIsAvailable => {
+              if (versionIsAvailable) {
+                return schemaManager.useSchema('in-network-rates');
+              } else {
+                return null;
+              }
+            })
+            .then(schemaPath => {
+              if (schemaPath != null) {
+                return dockerManager.runContainer(
                   schemaPath,
                   'in-network-rates',
                   dataPath,
                   tempOutput
                 );
-                if (
-                  containedResult.pass &&
-                  containedResult.locations?.providerReference?.length > 0
-                ) {
-                  containedResult.locations.providerReference.forEach(prf =>
-                    providerReferences.add(prf)
-                  );
-                }
-                if (tempOutput.length > 0) {
-                  appendResults(tempOutput, outputPath, `${dataUrl} - in-network${EOL}`);
-                }
               }
-            } else {
-              logger.error(`Could not download file: ${dataUrl}`);
-            }
-          } catch (err) {
-            logger.error('Problem validating referenced in-network file', err);
-          }
+            })
+            .then(containedResult => {
+              if (
+                containedResult.pass &&
+                containedResult.locations?.providerReference?.length > 0
+              ) {
+                containedResult.locations.providerReference.forEach(prf =>
+                  providerReferences.add(prf)
+                );
+              }
+              if (tempOutput.length > 0) {
+                appendResults(tempOutput, outputPath, `${dataUrl} - in-network${EOL}`);
+              }
+            });
         }
-      } else {
-        logger.error('No schema available - not validating.');
       }
-    });
+    } catch (err) {
+      logger.error('Problem validating referenced in-network file', err);
+    }
   }
-  if (allowedAmount.length > 0) {
-    await schemaManager.useSchema('allowed-amounts').then(async schemaPath => {
-      if (schemaPath != null) {
-        for (const dataUrl of allowedAmount) {
-          try {
-            if (await checkDataUrl(dataUrl)) {
-              logger.info(`File: ${dataUrl}`);
-              const dataPath = await downloadDataFile(dataUrl, temp.mkdirSync());
-              if (typeof dataPath === 'string') {
-                const containedResult = await dockerManager.runContainer(
+  return providerReferences;
+}
+
+async function validateAllowedAmountsFixedVersion(
+  allowedAmount: string[],
+  schemaManager: SchemaManager,
+  dockerManager: DockerManager,
+  outputPath: string,
+  tempOutput: string
+) {
+  await schemaManager.useSchema('allowed-amounts').then(async schemaPath => {
+    if (schemaPath != null) {
+      for (const dataUrl of allowedAmount) {
+        try {
+          if (await checkDataUrl(dataUrl)) {
+            logger.info(`File: ${dataUrl}`);
+            const dataPath = await downloadDataFile(dataUrl, temp.mkdirSync());
+            if (typeof dataPath === 'string') {
+              // check if detected version matches the provided version
+              // if there's no version property, that's ok
+              await schemaManager
+                .determineVersion(dataPath)
+                .then(detectedVersion => {
+                  if (detectedVersion != schemaManager.version) {
+                    logger.warn(
+                      `Schema version ${schemaManager.version} was provided, but file indicates it conforms to schema version ${detectedVersion}. ${schemaManager.version} will be used.`
+                    );
+                  }
+                })
+                .catch(() => {});
+              await dockerManager.runContainer(schemaPath, 'allowed-amounts', dataPath, tempOutput);
+              if (tempOutput.length > 0) {
+                appendResults(tempOutput, outputPath, `${dataUrl} - allowed-amounts${EOL}`);
+              }
+            }
+          } else {
+            logger.error(`Could not download file: ${dataUrl}`);
+          }
+        } catch (err) {
+          logger.error('Problem validating referenced allowed-amounts file', err);
+        }
+      }
+    } else {
+      logger.error('No schema available - not validating.');
+    }
+  });
+}
+
+async function validateAllowedAmountsDetectedVersion(
+  allowedAmount: string[],
+  schemaManager: SchemaManager,
+  dockerManager: DockerManager,
+  outputPath: string,
+  tempOutput: string
+) {
+  for (const dataUrl of allowedAmount) {
+    try {
+      if (await checkDataUrl(dataUrl)) {
+        logger.info(`File: ${dataUrl}`);
+        const dataPath = await downloadDataFile(dataUrl, temp.mkdirSync());
+        if (typeof dataPath === 'string') {
+          const versionToUse = await schemaManager.determineVersion(dataPath);
+          await schemaManager
+            .useVersion(versionToUse)
+            .then(versionIsAvailable => {
+              if (versionIsAvailable) {
+                return schemaManager.useSchema('allowed-amounts');
+              } else {
+                return null;
+              }
+            })
+            .then(schemaPath => {
+              if (schemaPath != null) {
+                return dockerManager.runContainer(
                   schemaPath,
                   'allowed-amounts',
                   dataPath,
                   tempOutput
                 );
-                if (tempOutput.length > 0) {
-                  appendResults(tempOutput, outputPath, `${dataUrl} - allowed-amounts${EOL}`);
-                }
               }
-            } else {
-              logger.error(`Could not download file: ${dataUrl}`);
-            }
-          } catch (err) {
-            logger.error('Problem validating referenced allowed-amounts file', err);
-          }
+            })
+            .then(_containedResult => {
+              if (tempOutput.length > 0) {
+                appendResults(tempOutput, outputPath, `${dataUrl} - allowed-amounts${EOL}`);
+              }
+            });
         }
-      } else {
-        logger.error('No schema available - not validating.');
       }
-    });
+    } catch (err) {
+      logger.error('Problem validating referenced allowed-amounts file', err);
+    }
   }
-  return [...providerReferences.values()];
 }
 
 export async function assessReferencedProviders(

--- a/test/SchemaManager.test.ts
+++ b/test/SchemaManager.test.ts
@@ -103,16 +103,14 @@ describe('SchemaManager', () => {
       (child_process.exec as jest.Mocked<typeof child_process_real.exec>).mockRestore();
     });
 
-    it('should return true when the version exists in the repo', async () => {
+    it('should resolve to true when the version exists in the repo', async () => {
       const schemaManager = new SchemaManager(repoDirectory);
-      const result = await schemaManager.useVersion('v0.7');
-      expect(result).toBeDefined();
+      await expect(schemaManager.useVersion('v0.7')).resolves.toBe(true);
     });
 
-    it('should return false when the version does not exist in the repo', async () => {
+    it('should reject when the version does not exist in the repo', async () => {
       const schemaManager = new SchemaManager(repoDirectory);
-      const result = await schemaManager.useVersion('v0.6');
-      expect(result).toBeFalse();
+      await expect(schemaManager.useVersion('v0.6')).toReject();
     });
   });
 
@@ -161,6 +159,26 @@ describe('SchemaManager', () => {
       await schemaManager.useVersion('v0.7');
       const result = await schemaManager.useSchema('something-else');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('#determineVersion', () => {
+    it('should resolve to the value of the version property when it exists and is a string', async () => {
+      const dataPath = path.join(__dirname, 'fixtures', 'dataWithVersion.json');
+      const schemaManager = new SchemaManager();
+      await expect(schemaManager.determineVersion(dataPath)).resolves.toBe('1.2.0');
+    });
+
+    it('should reject when the version property does not exist', async () => {
+      const dataPath = path.join(__dirname, 'fixtures', 'dataWithoutVersion.json');
+      const schemaManager = new SchemaManager();
+      await expect(schemaManager.determineVersion(dataPath)).toReject();
+    });
+
+    it('should reject when the version property exists, but is not a string', async () => {
+      const dataPath = path.join(__dirname, 'fixtures', 'dataNonStringVersion.json');
+      const schemaManager = new SchemaManager();
+      await expect(schemaManager.determineVersion(dataPath)).toReject();
     });
   });
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -28,39 +28,27 @@ describe('commands', () => {
     });
 
     it('should continue processing when the data file exists', async () => {
-      await validate(
-        path.join(__dirname, '..', 'test-files', 'allowed-amounts.json'),
-        'schema version 278',
-        { target: null }
-      );
+      await validate(path.join(__dirname, '..', 'test-files', 'allowed-amounts.json'), {
+        target: null
+      });
       expect(useVersionSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should not continue processing when the data file does not exist', async () => {
-      await validate(
-        path.join(__dirname, '..', 'test-files', 'not-real.json'),
-        'schema version 8',
-        { target: null }
-      );
+      await validate(path.join(__dirname, '..', 'test-files', 'not-real.json'), { target: null });
       expect(useVersionSpy).toHaveBeenCalledTimes(0);
     });
 
     it('should run the container when the requested schema is available', async () => {
       useSchemaSpy.mockResolvedValueOnce('good.json');
-      await validate(
-        path.join(__dirname, '..', 'test-files', 'allowed-amounts.json'),
-        'schema version 278',
-        { target: null }
-      );
+      await validate(path.join(__dirname, '..', 'test-files', 'allowed-amounts.json'), {
+        target: null
+      });
       expect(runContainerSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should not run the container when the requested schema is not available', async () => {
-      await validate(
-        path.join(__dirname, '..', 'test-files', 'not-real.json'),
-        'schema version 278',
-        { target: null }
-      );
+      await validate(path.join(__dirname, '..', 'test-files', 'not-real.json'), { target: null });
       expect(runContainerSpy).toHaveBeenCalledTimes(0);
     });
 
@@ -99,13 +87,13 @@ describe('commands', () => {
 
     it('should continue processing when the data url is valid and content length is less than or equal to the size limit', async () => {
       checkDataUrlSpy.mockResolvedValueOnce(true);
-      await validateFromUrl('http://example.org/data.json', 'v1.0.0', {});
+      await validateFromUrl('http://example.org/data.json', { schemaVersion: 'v1.0.0' });
       expect(useSchemaSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should not continue processing when the data url is invalid', async () => {
       checkDataUrlSpy.mockResolvedValueOnce(false);
-      await validateFromUrl('http://example.org/data.json', 'v1.0.0', {});
+      await validateFromUrl('http://example.org/data.json', { schemaVersion: 'v1.0.0' });
       expect(useSchemaSpy).toHaveBeenCalledTimes(0);
     });
 
@@ -113,8 +101,9 @@ describe('commands', () => {
       checkDataUrlSpy.mockResolvedValueOnce(true);
       useSchemaSpy.mockResolvedValueOnce('schemapath.json');
       downloadDataSpy.mockResolvedValueOnce('data.json');
-      await validateFromUrl('http://example.org/data.json', 'v1.0.0', {
-        target: 'in-network-rates'
+      await validateFromUrl('http://example.org/data.json', {
+        target: 'in-network-rates',
+        schemaVersion: 'v1.0.0'
       });
       expect(downloadDataSpy).toHaveBeenCalledTimes(1);
       expect(downloadDataSpy).toHaveBeenCalledWith(
@@ -133,7 +122,7 @@ describe('commands', () => {
     it('should not download the data file when the requested schema is not available', async () => {
       checkDataUrlSpy.mockResolvedValueOnce(true);
       useSchemaSpy.mockResolvedValueOnce(null);
-      await validateFromUrl('http://example.org/data.json', 'v1.0.0', {});
+      await validateFromUrl('http://example.org/data.json', { schemaVersion: 'v1.0.0' });
       expect(downloadDataSpy).toHaveBeenCalledTimes(0);
     });
 

--- a/test/fixtures/dataNonStringVersion.json
+++ b/test/fixtures/dataNonStringVersion.json
@@ -1,0 +1,10 @@
+{
+  "reporting_entity_name": "medicare",
+  "reporting_entity_type": "medicare",
+  "plan_name": "medicaid",
+  "plan_id_type": "hios",
+  "plan_id": "1111111111",
+  "plan_market_type": "individual",
+  "last_updated_on": "2020-08-27",
+  "version": 1.5
+}

--- a/test/fixtures/dataWithVersion.json
+++ b/test/fixtures/dataWithVersion.json
@@ -1,0 +1,10 @@
+{
+  "reporting_entity_name": "medicare",
+  "reporting_entity_type": "medicare",
+  "plan_name": "medicaid",
+  "plan_id_type": "hios",
+  "plan_id": "1111111111",
+  "plan_market_type": "individual",
+  "last_updated_on": "2020-08-27",
+  "version": "1.2.0"
+}

--- a/test/fixtures/dataWithoutVersion.json
+++ b/test/fixtures/dataWithoutVersion.json
@@ -1,0 +1,9 @@
+{
+  "reporting_entity_name": "medicare",
+  "reporting_entity_type": "medicare",
+  "plan_name": "medicaid",
+  "plan_id_type": "hios",
+  "plan_id": "1111111111",
+  "plan_market_type": "individual",
+  "last_updated_on": "2020-08-27"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "module": "commonjs" /* Specify what module code is generated. */,
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {


### PR DESCRIPTION
Addresses #92.

Schema version is now an optional argument rather than a required argument. If schema version is not provided, look for a version property in the data file. If found, try to use it as if it were the argument value. If not found, log an error and exit. If schema version is provided, still look for a version property in the data file. If it does not match the provided version, log a warning. The provided version is always used when available.

This is a significant change to the usage of the command-line interface. When this feature is released, be sure to make that fact very clear in the release notes.