### PR TITLE
Remove encoding from buffer string conversion

### DIFF
--- a/src/SchemaManager.ts
+++ b/src/SchemaManager.ts
@@ -145,7 +145,7 @@ export class SchemaManager {
                 length: BACKWARDS_BYTES
               });
               if (lastStuff.bytesRead > 0) {
-                const lastText = lastStuff.buffer.toString('utf-8');
+                const lastText = lastStuff.buffer.toString();
                 const versionRegex = /"version"\s*:\s*("(?:\\"|\\\\|[^"])*")/;
                 const versionMatch = lastText.match(versionRegex);
                 if (versionMatch) {


### PR DESCRIPTION
Address issues caused by invalid parameter 'utf-8' in toString()
Passing 'utf-8' will either be ignored or cause a TypeScript compile-time error.