### PR TITLE
Version documentation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Error report:
 }
 ```
 
+### Known Validator Issues for Transparency in Coverage Schema Version 2.0.0
+
+This validator uses the [RapidJSON](https://rapidjson.org) library, which has a [known issue](https://github.com/Tencent/rapidjson/issues/2314) with JSON Schema validation of `oneOf` and `const` keywords. To work around this, @clovis517 introduced a [schema patch](https://github.com/CMSgov/price-transparency-guide/pull/897/changes/23972ca27428fc675bf315b661675eeeee85e9f0) that preserves the expected validation behavior while avoiding the RapidJSON limitations. As a result, this validator automatically translates `--schema-version v2.0.0` to `--schema-version v2.1.0`.
+
 ### Performance Considerations
 
 This validation tool is based on [rapidjson](https://rapidjson.org/) which is a high performance C++ JSON parser. You can find various benchmarks on [rapidjson's site](https://rapidjson.org/md_doc_performance.html) that should give the user an idea on what to expect when using.

--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ Error report:
 }
 ```
 
-### Known Validator Issues for Transparency in Coverage Schema Version 2.0.0
+### Known Validator Issues for Transparency in Coverage Schema Versions 2.0.0 and 2.0.1
 
-This validator uses the [RapidJSON](https://rapidjson.org) library, which has a [known issue](https://github.com/Tencent/rapidjson/issues/2314) with JSON Schema validation of `oneOf` and `const` keywords. To work around this, @clovis517 introduced a [schema patch](https://github.com/CMSgov/price-transparency-guide/pull/897/changes/23972ca27428fc675bf315b661675eeeee85e9f0) that preserves the expected validation behavior while avoiding the RapidJSON limitations. As a result, this validator automatically translates `--schema-version v2.0.0` to `--schema-version v2.1.0`.
+This validator uses the [RapidJSON](https://rapidjson.org) library, which has a [known issue](https://github.com/Tencent/rapidjson/issues/2314) with JSON Schema validation of `oneOf` and `const` keywords. To work around this, @clovis517 introduced a [schema patch](https://github.com/CMSgov/price-transparency-guide/pull/897/changes/23972ca27428fc675bf315b661675eeeee85e9f0) that preserves the expected validation behavior while avoiding the RapidJSON limitations. As a result, this validator automatically translates versions 2.0.0 and 2.0.1 to version 2.1.0. This happens whether the version is passed via a CLI flag (e.g., `--schema-version v2.0.0`) or detected automatically within the machine-readable file.
 
 ### Performance Considerations
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,6 +38,10 @@ export async function validate(dataFile: string, options: OptionValues) {
       );
     }
     versionToUse = schemaManager.shouldDetectVersion ? detectedVersion : options.schemaVersion;
+    if (/^v?2\.0\.0$/.test(versionToUse)) {
+      logger.info('v2.0.0 has some problems with the tooling. Using v2.1.0 instead.');
+      versionToUse = 'v2.1.0';
+    }
   } catch {
     if (!schemaManager.shouldDetectVersion) {
       versionToUse = options.schemaVersion;
@@ -112,8 +116,13 @@ export async function validateFromUrl(dataUrl: string, options: OptionValues) {
     const schemaManager = new SchemaManager();
     await schemaManager.ensureRepo();
     schemaManager.strict = options.strict;
+    let versionToUse: string = options.schemaVersion;
+    if (/^v?2\.0\.0$/.test(versionToUse)) {
+      logger.info('v2.0.0 has some problems with the tooling. Using v2.1.0 instead.');
+      versionToUse = 'v2.1.0';
+    }
     return schemaManager
-      .useVersion(options.schemaVersion)
+      .useVersion(versionToUse)
       .then(versionIsAvailable => {
         if (versionIsAvailable) {
           return schemaManager.useSchema(options.target);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,8 +38,8 @@ export async function validate(dataFile: string, options: OptionValues) {
       );
     }
     versionToUse = schemaManager.shouldDetectVersion ? detectedVersion : options.schemaVersion;
-    if (/^v?2\.0\.0$/.test(versionToUse)) {
-      logger.info('v2.0.0 has some problems with the tooling. Using v2.1.0 instead.');
+    if (/^v?2\.0\.[01]$/.test(versionToUse)) {
+      logger.info('v2.0.0 and v2.0.1 has some problems with the tooling. Using v2.1.0 instead.');
       versionToUse = 'v2.1.0';
     }
   } catch {
@@ -117,8 +117,8 @@ export async function validateFromUrl(dataUrl: string, options: OptionValues) {
     await schemaManager.ensureRepo();
     schemaManager.strict = options.strict;
     let versionToUse: string = options.schemaVersion;
-    if (/^v?2\.0\.0$/.test(versionToUse)) {
-      logger.info('v2.0.0 has some problems with the tooling. Using v2.1.0 instead.');
+    if (/^v?2\.0\.[01]$/.test(versionToUse)) {
+      logger.info('v2.0.0 and v2.0.1 has some problems with the tooling. Using v2.1.0 instead.');
       versionToUse = 'v2.1.0';
     }
     return schemaManager


### PR DESCRIPTION
The RapidJSON validator dependency has known bugs handling `const` attribute within `oneOf`schema constructs. This causes false validation failures against the v2.0.0 and v2.0.1 schemas.

To work around this, the validator now automatically redirects validation runs targeting v2.0.0 or v2.0.1 to the v2.1.0 schema, which preserves the same validation requirements while avoiding the RapidJSON limitations.

This has been documented in the following Issues found on the main Transparency in Coverage Github:

- https://github.com/CMSgov/price-transparency-guide/issues/901
- https://github.com/CMSgov/price-transparency-guide/issues/882
- https://github.com/CMSgov/price-transparency-guide-validator/issues/137
- https://github.com/CMSgov/price-transparency-guide-validator/issues/138
- https://github.com/CMSgov/price-transparency-guide/issues/900

Thank you @clovis517 for all your help on this.
