### PR TITLE
Handle missing optional setting in referenced allowed-amount files

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -423,7 +423,11 @@ async function validateAllowedAmountsDetectedVersion(
         logger.info(`File: ${dataUrl}`);
         const dataPath = await downloadManager.downloadDataFile(dataUrl);
         if (typeof dataPath === 'string') {
-          const versionToUse = await schemaManager.determineVersion(dataPath);
+          let versionToUse = await schemaManager.determineVersion(dataPath);
+          if (/^v?2\.0\.[01]$/.test(versionToUse)) {
+            logger.info('v2.0.0 and v2.0.1 has some problems with the tooling. Using v2.1.0 instead.');
+            versionToUse = 'v2.1.0';
+          }
           await schemaManager
             .useVersion(versionToUse)
             .then(versionIsAvailable => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,66 @@
+import 'jest-extended';
+import { validateTocContents } from '../src/utils';
+import { SchemaManager } from '../src/SchemaManager';
+import { DockerManager } from '../src/DockerManager';
+import { DownloadManager } from '../src/DownloadManager';
+
+describe('utils', () => {
+  let checkDataUrlSpy: jest.SpyInstance;
+  let downloadDataFileSpy: jest.SpyInstance;
+  let determineVersionSpy: jest.SpyInstance;
+  let useVersionSpy: jest.SpyInstance;
+  let useSchemaSpy: jest.SpyInstance;
+  let runContainerSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    checkDataUrlSpy = jest.spyOn(DownloadManager.prototype, 'checkDataUrl').mockResolvedValue(true);
+    downloadDataFileSpy = jest
+      .spyOn(DownloadManager.prototype, 'downloadDataFile')
+      .mockResolvedValue('data.json');
+    determineVersionSpy = jest
+      .spyOn(SchemaManager.prototype, 'determineVersion')
+      .mockResolvedValue('v1.0.0');
+    useVersionSpy = jest.spyOn(SchemaManager.prototype, 'useVersion').mockResolvedValue(true);
+    useSchemaSpy = jest.spyOn(SchemaManager.prototype, 'useSchema').mockResolvedValue('schemaPath');
+    runContainerSpy = jest
+      .spyOn(DockerManager.prototype, 'runContainer')
+      .mockResolvedValue({ pass: true, locations: { providerReference: [] } });
+  });
+
+  beforeEach(() => {
+    checkDataUrlSpy.mockClear();
+    downloadDataFileSpy.mockClear();
+    determineVersionSpy.mockClear();
+    useVersionSpy.mockClear();
+    useSchemaSpy.mockClear();
+    runContainerSpy.mockClear();
+  });
+
+  afterAll(() => {
+    checkDataUrlSpy.mockRestore();
+    downloadDataFileSpy.mockRestore();
+    determineVersionSpy.mockRestore();
+    useVersionSpy.mockRestore();
+    useSchemaSpy.mockRestore();
+    runContainerSpy.mockRestore();
+  });
+
+  it('uses v2.1.0 when referenced allowed-amounts file version is v2.0.0', async () => {
+    determineVersionSpy.mockResolvedValueOnce('v1.0.0').mockResolvedValueOnce('v2.0.0');
+    const schemaManager = new SchemaManager();
+    schemaManager.shouldDetectVersion = true;
+    const dockerManager = new DockerManager();
+    const downloadManager = new DownloadManager(true);
+
+    await validateTocContents(
+      ['https://example.org/in-network-rates.json'],
+      ['https://example.org/allowed-amounts.json'],
+      schemaManager,
+      dockerManager,
+      downloadManager
+    );
+
+    expect(useVersionSpy).toHaveBeenNthCalledWith(1, 'v1.0.0');
+    expect(useVersionSpy).toHaveBeenNthCalledWith(2, 'v2.1.0');
+  });
+});


### PR DESCRIPTION
When we validate referenced allowed-amount files via table-of-contents with detected schema versions, v2.0.0 and v2.0.1 were still used directly. That can trigger a false failure when setting is missing even though it is optional in the corrected schema behavior.

This applies the same v2.0.x to v2.1.0 fallback in that code path and adds a regression test for it.

Fixes #133